### PR TITLE
Do not set pluginUntilBuild to allow using with future releases

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ intellij {
     version.set(properties("platformVersion"))
     type.set(properties("platformType"))
     downloadSources.set(properties("platformDownloadSources").toBoolean())
-    updateSinceUntilBuild.set(true)
+    updateSinceUntilBuild.set(false)
 
     // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
     plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
@@ -92,7 +92,6 @@ tasks {
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))
-        untilBuild.set(properties("pluginUntilBuild"))
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ pluginVersion = 0.3.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
+# Only set the minimum version and not pluginUntilBuild
 pluginSinceBuild = 202
-pluginUntilBuild = 211.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.


### PR DESCRIPTION
This should allow using the same plugin with future IntelliJ releases
and fix #1.

Briefly looking e.g. discussion at https://intellij-support.jetbrains.com/hc/en-us/community/posts/360010590059-Why-pluginUntilBuild-is-mandatory
it seems that this is acceptable approach but validity
against future releases should be checked using intellij-plugin-verifier.

As of writing, the current latest version number is 202 matching
JetBrains products 2021.2.*.

The output of the intellij-plugin-verifier says this plugin is still compatible:

  2021-11-10T21:03:56 [main] INFO  verification - Finished 1 of 1 verifications (in 2.6 s): IU-212.5457.46 against org.zig:0.3.1: Compatible. 3 usages of deprecated API. 1 usage of internal API
  Plugin org.zig:0.3.1 against IU-212.5457.46: Compatible. 3 usages of deprecated API. 1 usage of internal API
  Deprecated API usages (3):
    \#Deprecated method com.intellij.openapi.util.IconLoader.getIcon(String) invocation
        Deprecated method com.intellij.openapi.util.IconLoader.getIcon(java.lang.String path) : javax.swing.Icon is invoked in org.zig.ZigIcons.<clinit>() : void
    \#Deprecated method com.intellij.openapi.project.Project.getBaseDir() invocation
        Deprecated method com.intellij.openapi.project.Project.getBaseDir() : com.intellij.openapi.vfs.VirtualFile is invoked in org.zig.runner.ZigCompilerOutputFilter.applyFilter(String, int) : Filter.Result
    \#Deprecated method com.intellij.lang.ParserDefinition.spaceExistanceTypeBetweenTokens(ASTNode, ASTNode) is overridden
        Deprecated method com.intellij.lang.ParserDefinition.spaceExistanceTypeBetweenTokens(com.intellij.lang.ASTNode left, com.intellij.lang.ASTNode right) : com.intellij.lang.ParserDefinition.SpaceRequirements is overridden in class org.zig.ZigParserDefinition
  Internal API usages (1):
    \#Internal method com.intellij.execution.ExecutionManager.startRunProfile(ExecutionEnvironment, Function0) invocation
        Internal method com.intellij.execution.ExecutionManager.startRunProfile(com.intellij.execution.runners.ExecutionEnvironment arg0, kotlin.jvm.functions.Function0 arg1) : void is invoked in org.zig.runner.ZigRunner.execute(ExecutionEnvironment) : void. This method is marked with @org.jetbrains.annotations.ApiStatus.Internal annotation and indicates that the method is not supposed to be used in client code.
    Plugin can be loaded/unloaded without IDE restart